### PR TITLE
feat: HITL paper selection, conditional interrupt & UI improvements

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,15 @@
       "mcp__docs-mcp-server__scrape_docs",
       "mcp__docs-mcp-server__get_job_info",
       "mcp__docs-mcp-server__fetch_url",
-      "Bash(git stash pop:*)"
+      "Bash(git stash pop:*)",
+      "Bash(git add:*)",
+      "Bash(fly deploy:*)",
+      "Bash(fly secrets set:*)",
+      "Bash(uv lock:*)",
+      "Bash(fly apps create:*)",
+      "Bash(fly machines list:*)",
+      "Bash(fly machines destroy:*)",
+      "Bash(pnpm tsc:*)"
     ]
   }
 }

--- a/web/src/components/agent/ui.tsx
+++ b/web/src/components/agent/ui.tsx
@@ -136,7 +136,7 @@ interface TaskPollStatus {
 
 export const PaperListComponent = (props: PaperListComponentProps) => {
   const paperCount = props.papers?.length || 0;
-  const { selectPaper } = usePaperSelection(); // Only used to add to persistent list after ingestion
+  const { selectPaper, deselectPaper } = usePaperSelection();
   const [tempSelected, setTempSelected] = useState<Set<string>>(new Set()); // Temporary checkbox selections
   const [ingestStatus, setIngestStatus] = useState<IngestStatus>({ status: 'idle' });
   const [taskStatuses, setTaskStatuses] = useState<TaskPollStatus[]>([]);
@@ -231,6 +231,13 @@ export const PaperListComponent = (props: PaperListComponentProps) => {
       }
       return newSet;
     });
+    // Sync to global context so "Yes, proceed" button reflects checkbox state
+    if (selected) {
+      const paper = props.papers.find(p => p.paperId === paperId);
+      if (paper) selectPaper(paper);
+    } else {
+      deselectPaper(paperId);
+    }
   };
 
   const handleAddToPaperList = async () => {

--- a/web/src/components/agent/ui.tsx
+++ b/web/src/components/agent/ui.tsx
@@ -136,7 +136,7 @@ interface TaskPollStatus {
 
 export const PaperListComponent = (props: PaperListComponentProps) => {
   const paperCount = props.papers?.length || 0;
-  const { selectPaper, deselectPaper } = usePaperSelection();
+  const { selectPaper } = usePaperSelection();
   const [tempSelected, setTempSelected] = useState<Set<string>>(new Set()); // Temporary checkbox selections
   const [ingestStatus, setIngestStatus] = useState<IngestStatus>({ status: 'idle' });
   const [taskStatuses, setTaskStatuses] = useState<TaskPollStatus[]>([]);
@@ -231,12 +231,15 @@ export const PaperListComponent = (props: PaperListComponentProps) => {
       }
       return newSet;
     });
-    // Sync to global context so "Yes, proceed" button reflects checkbox state
-    if (selected) {
-      const paper = props.papers.find(p => p.paperId === paperId);
-      if (paper) selectPaper(paper);
+  };
+
+  const allSelected = paperCount > 0 && tempSelected.size === paperCount;
+
+  const handleSelectAll = () => {
+    if (allSelected) {
+      setTempSelected(new Set());
     } else {
-      deselectPaper(paperId);
+      setTempSelected(new Set(props.papers.map(p => p.paperId).filter(Boolean) as string[]));
     }
   };
 
@@ -325,10 +328,17 @@ export const PaperListComponent = (props: PaperListComponentProps) => {
             <h3 className="text-base font-semibold text-gray-900">
               Found {paperCount} Paper{paperCount !== 1 ? 's' : ''}
             </h3>
-            <p className="text-xs text-gray-400 mt-0.5">
+            <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1.5">
               {selectedCount > 0
                 ? `${selectedCount} paper${selectedCount !== 1 ? 's' : ''} selected`
                 : 'Check papers below to add them to your list'}
+              <span className="text-gray-300">·</span>
+              <button
+                onClick={handleSelectAll}
+                className="text-gray-500 hover:text-gray-800 underline underline-offset-2 transition-colors"
+              >
+                {allSelected ? 'Deselect all' : 'Select all'}
+              </button>
             </p>
           </div>
           <button

--- a/web/src/components/agent/ui.tsx
+++ b/web/src/components/agent/ui.tsx
@@ -19,26 +19,32 @@ interface StepTrackerProps {
 
 export const StepTracker = ({ steps }: StepTrackerProps) => {
   return (
-    <div className="w-xl max-w-3xl rounded-lg border border-gray-200 bg-white p-4 space-y-3 shadow-sm">
-      <div className="flex items-center gap-2 mb-3">
-        <svg className="w-5 h-5 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <div className="w-xl max-w-3xl rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-200">
+        <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
         </svg>
-        <h3 className="font-semibold text-gray-900">Agent Actions</h3>
+        <h3 className="text-base font-semibold text-gray-900">Agent Actions</h3>
       </div>
 
-      <div className="space-y-2">
-        {steps.map((step, index) => (
+      {/* Steps */}
+      <div className="divide-y divide-gray-100">
+        {steps.map((step) => (
           <div
             key={step.id}
-            className={`flex items-start gap-3 p-3 rounded-md transition-all ${
-              step.status === 'running' ? 'bg-gray-50 border border-gray-200' : ''
+            className={`group flex items-start gap-3 px-4 py-3 cursor-default transition-colors duration-150 ${
+              step.status === 'running'
+                ? 'bg-gray-50 hover:bg-gray-100'
+                : step.status === 'error'
+                ? 'hover:bg-red-50/50'
+                : 'hover:bg-gray-50'
             }`}
           >
-            {/* Status Icon */}
-            <div className="flex-shrink-0 mt-0.5">
+            {/* Status icon */}
+            <div className="flex-shrink-0 mt-0.5 w-5 h-5 flex items-center justify-center">
               {step.status === 'completed' && (
-                <svg className="w-5 h-5 text-gray-900" fill="currentColor" viewBox="0 0 20 20">
+                <svg className="w-5 h-5 text-gray-900 group-hover:text-black transition-colors" fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                 </svg>
               )}
@@ -49,36 +55,39 @@ export const StepTracker = ({ steps }: StepTrackerProps) => {
                 </svg>
               )}
               {step.status === 'pending' && (
-                <div className="w-5 h-5 rounded-full border-2 border-gray-300" />
+                <div className="w-4 h-4 rounded-full border-2 border-gray-300 group-hover:border-gray-400 transition-colors" />
               )}
               {step.status === 'error' && (
-                <svg className="w-5 h-5 text-red-600" fill="currentColor" viewBox="0 0 20 20">
+                <svg className="w-5 h-5 text-red-500 group-hover:text-red-600 transition-colors" fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
                 </svg>
               )}
             </div>
 
-            {/* Step Content */}
+            {/* Content */}
             <div className="flex-1 min-w-0">
-              <div className={`font-medium ${
-                step.status === 'running' ? 'text-gray-900' :
-                step.status === 'completed' ? 'text-gray-700' :
-                step.status === 'error' ? 'text-red-700' :
-                'text-gray-500'
+              <p className={`text-sm font-medium leading-snug transition-colors ${
+                step.status === 'running'   ? 'text-gray-900' :
+                step.status === 'completed' ? 'text-gray-600 group-hover:text-gray-900' :
+                step.status === 'error'     ? 'text-red-700' :
+                'text-gray-400 group-hover:text-gray-500'
               }`}>
                 {step.label}
-              </div>
+              </p>
               {step.description && (
-                <div className="text-sm text-gray-600 mt-1">
+                <p className="text-xs text-gray-400 mt-0.5 leading-snug group-hover:text-gray-500 transition-colors">
                   {step.description}
-                </div>
+                </p>
               )}
             </div>
 
-            {/* Connector Line (except for last item) */}
-            {index < steps.length - 1 && step.status !== 'pending' && (
-              <div className="absolute left-[34px] top-10 w-0.5 h-full bg-gray-200"
-                   style={{ height: '24px' }} />
+            {/* Running indicator */}
+            {step.status === 'running' && (
+              <div className="flex-shrink-0 self-center">
+                <span className="text-xs text-gray-500 group-hover:text-gray-700 transition-colors">
+                  Running…
+                </span>
+              </div>
             )}
           </div>
         ))}

--- a/web/src/components/thread/index.tsx
+++ b/web/src/components/thread/index.tsx
@@ -383,11 +383,17 @@ export function Thread() {
             footer={
               <div className="sticky flex flex-col items-center gap-8 bottom-0 bg-white">
                 {!chatStarted && (
-                  <div className="flex gap-3 items-center">
-                    <CorvusSVG className="flex-shrink-0 h-8" />
-                    <h1 className="text-2xl font-semibold tracking-tight">
-                      Corvus
-                    </h1>
+                  <div className="flex flex-col items-start gap-2 w-full max-w-3xl">
+                    <div className="flex gap-3 items-center">
+                      <CorvusSVG className="flex-shrink-0 h-12" />
+                      <h1 className="text-4xl font-semibold tracking-tight">
+                        Corvus
+                      </h1>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      <span className="font-semibold text-foreground">An AI research assistant for academic literature.</span>{" "}
+                      Find relevant papers, build your reading list, and get evidence-backed answers to your research questions.
+                    </p>
                   </div>
                 )}
 
@@ -421,7 +427,7 @@ export function Thread() {
                       placeholder={
                         isInterrupted
                           ? "Please respond to the question above first..."
-                          : "Type your message..."
+                          : "Find papers, ask a question, or both…"
                       }
                       className={cn(
                         "p-3.5 pb-0 border-none bg-transparent field-sizing-content shadow-none ring-0 outline-none focus:outline-none focus:ring-0 resize-none",

--- a/web/src/components/thread/messages/ai.tsx
+++ b/web/src/components/thread/messages/ai.tsx
@@ -76,10 +76,12 @@ export function AssistantMessage({
   message,
   isLoading,
   handleRegenerate,
+  onInterruptNo,
 }: {
   message: Message | undefined;
   isLoading: boolean;
   handleRegenerate: (parentCheckpoint: Checkpoint | null | undefined) => void;
+  onInterruptNo?: () => void;
 }) {
   const content = message?.content ?? [];
   const contentString = getContentString(content);
@@ -152,7 +154,7 @@ export function AssistantMessage({
           !isAgentInboxInterruptSchema(threadInterrupt.value) &&
           isLastMessage ? (
             threadInterrupt.value === "select_papers" ? (
-              <SelectPapersInterruptView />
+              <SelectPapersInterruptView onNo={onInterruptNo ?? (() => {})} />
             ) : (
               <GenericInterruptView interrupt={threadInterrupt.value} />
             )

--- a/web/src/components/thread/messages/ai.tsx
+++ b/web/src/components/thread/messages/ai.tsx
@@ -76,12 +76,10 @@ export function AssistantMessage({
   message,
   isLoading,
   handleRegenerate,
-  onInterruptNo,
 }: {
   message: Message | undefined;
   isLoading: boolean;
   handleRegenerate: (parentCheckpoint: Checkpoint | null | undefined) => void;
-  onInterruptNo?: () => void;
 }) {
   const content = message?.content ?? [];
   const contentString = getContentString(content);
@@ -154,7 +152,7 @@ export function AssistantMessage({
           !isAgentInboxInterruptSchema(threadInterrupt.value) &&
           isLastMessage ? (
             threadInterrupt.value === "select_papers" ? (
-              <SelectPapersInterruptView onNo={onInterruptNo ?? (() => {})} />
+              <SelectPapersInterruptView />
             ) : (
               <GenericInterruptView interrupt={threadInterrupt.value} />
             )

--- a/web/src/components/thread/messages/select-papers-interrupt.tsx
+++ b/web/src/components/thread/messages/select-papers-interrupt.tsx
@@ -1,22 +1,49 @@
 import { CheckCircle } from "lucide-react";
 import { usePaperSelection } from "@/providers/PaperSelection";
+import { useStreamContext } from "@/providers/Stream";
+import { Button } from "@/components/ui/button";
 
-export function SelectPapersInterruptView() {
+export function SelectPapersInterruptView({ onNo }: { onNo: () => void }) {
   const { selectedPaperIds } = usePaperSelection();
+  const stream = useStreamContext();
   const count = selectedPaperIds.length;
 
+  const handleYes = () => {
+    stream.submit(
+      {},
+      {
+        command: {
+          resume: {
+            selected_paper_ids: selectedPaperIds,
+            user_message: null,
+          },
+        },
+        streamMode: ["values"],
+      },
+    );
+  };
+
   return (
-    <div className="border border-emerald-200 bg-emerald-50 rounded-lg px-4 py-3 flex items-start gap-3">
-      <CheckCircle className="text-emerald-600 mt-0.5 shrink-0 w-5 h-5" />
-      <div className="text-sm text-emerald-900">
-        <p className="font-medium mb-0.5">Papers retrieved</p>
-        <p className="text-emerald-700">
-          {count > 0
-            ? `${count} paper${count !== 1 ? "s" : ""} selected. `
-            : "No papers selected yet. "}
-          Select papers from the list above, then type what you'd like to do
-          next — or click <strong>Continue</strong> to proceed.
-        </p>
+    <div className="border border-emerald-200 bg-emerald-50 rounded-lg px-4 py-4 flex flex-col gap-3">
+      <div className="flex items-start gap-3">
+        <CheckCircle className="text-emerald-600 mt-0.5 shrink-0 w-5 h-5" />
+        <div className="text-sm text-emerald-900">
+          <p className="font-medium mb-0.5">Papers retrieved</p>
+          <p className="text-emerald-700">
+            {count > 0
+              ? `${count} paper${count !== 1 ? "s" : ""} selected.`
+              : "No papers selected yet."}{" "}
+            Would you like to proceed with these results?
+          </p>
+        </div>
+      </div>
+      <div className="flex gap-2 ml-8">
+        <Button size="sm" onClick={handleYes} disabled={count === 0}>
+          Yes, proceed
+        </Button>
+        <Button size="sm" variant="outline" onClick={onNo}>
+          No, search again
+        </Button>
       </div>
     </div>
   );

--- a/web/src/components/thread/messages/select-papers-interrupt.tsx
+++ b/web/src/components/thread/messages/select-papers-interrupt.tsx
@@ -1,12 +1,13 @@
-import { CheckCircle } from "lucide-react";
+import { TriangleAlert, CheckCircle2 } from "lucide-react";
 import { usePaperSelection } from "@/providers/PaperSelection";
 import { useStreamContext } from "@/providers/Stream";
 import { Button } from "@/components/ui/button";
 
-export function SelectPapersInterruptView({ onNo }: { onNo: () => void }) {
+export function SelectPapersInterruptView() {
   const { selectedPaperIds } = usePaperSelection();
   const stream = useStreamContext();
   const count = selectedPaperIds.length;
+  const hasSelection = count > 0;
 
   const handleYes = () => {
     stream.submit(
@@ -23,26 +24,52 @@ export function SelectPapersInterruptView({ onNo }: { onNo: () => void }) {
     );
   };
 
+  const handleNo = () => {
+    stream.submit(
+      {},
+      {
+        command: {
+          resume: {
+            selected_paper_ids: [],
+            user_message: null,
+          },
+        },
+        streamMode: ["values"],
+      },
+    );
+  };
+
   return (
-    <div className="border border-emerald-200 bg-emerald-50 rounded-lg px-4 py-4 flex flex-col gap-3">
+    <div
+      className={`rounded-lg border-l-4 px-4 py-4 flex flex-col gap-3 transition-colors ${
+        hasSelection
+          ? "border-l-emerald-500 border border-emerald-200 bg-emerald-50"
+          : "border-l-amber-500 border border-amber-200 bg-amber-50"
+      }`}
+    >
       <div className="flex items-start gap-3">
-        <CheckCircle className="text-emerald-600 mt-0.5 shrink-0 w-5 h-5" />
-        <div className="text-sm text-emerald-900">
-          <p className="font-medium mb-0.5">Papers retrieved</p>
-          <p className="text-emerald-700">
-            {count > 0
-              ? `${count} paper${count !== 1 ? "s" : ""} selected.`
-              : "No papers selected yet."}{" "}
-            Would you like to proceed with these results?
+        {hasSelection ? (
+          <CheckCircle2 className="text-emerald-600 mt-0.5 shrink-0 w-5 h-5" />
+        ) : (
+          <TriangleAlert className="text-amber-500 mt-0.5 shrink-0 w-5 h-5" />
+        )}
+        <div className="text-sm">
+          <p className={`font-semibold mb-0.5 ${hasSelection ? "text-emerald-900" : "text-amber-900"}`}>
+            {hasSelection ? `${count} paper${count !== 1 ? "s" : ""} selected` : "Action required before proceeding"}
+          </p>
+          <p className={hasSelection ? "text-emerald-700" : "text-amber-800"}>
+            {hasSelection
+              ? `Your question will be answered using the selected paper${count !== 1 ? "s" : ""}. Make sure ingestion has finished before clicking Proceed.`
+              : "Since you asked a question about these papers, their full content must be ingested before an answer can be generated. Select the relevant papers above, click \"Add to list\", and wait for ingestion to complete — then click Proceed. If none of the papers are relevant, click Reject."}
           </p>
         </div>
       </div>
       <div className="flex gap-2 ml-8">
-        <Button size="sm" onClick={handleYes} disabled={count === 0}>
-          Yes, proceed
+        <Button size="default" onClick={handleYes} disabled={!hasSelection}>
+          Proceed
         </Button>
-        <Button size="sm" variant="outline" onClick={onNo}>
-          No, search again
+        <Button size="default" variant="outline" onClick={handleNo}>
+          Reject
         </Button>
       </div>
     </div>

--- a/web/src/components/thread/selected-papers-panel/index.tsx
+++ b/web/src/components/thread/selected-papers-panel/index.tsx
@@ -31,7 +31,7 @@ function SelectedPapersContent() {
               {selectedPapers.size}
             </span>
           </div>
-          <p className="text-xs text-gray-500">Papers added to your research collection</p>
+          <p className="text-xs text-gray-500">Papers available to the research assistant</p>
         </div>
         <Button
           variant="ghost"
@@ -66,7 +66,7 @@ function SelectedPapersContent() {
               No papers in your list
             </h3>
             <p className="text-sm text-gray-500">
-              Add papers from search results to build your collection
+              Add papers from search results to make them available to the research assistant
             </p>
           </div>
         ) : (

--- a/web/src/providers/Thread.tsx
+++ b/web/src/providers/Thread.tsx
@@ -39,19 +39,22 @@ export function ThreadProvider({ children }: { children: ReactNode }) {
   const [threads, setThreads] = useState<Thread[]>([]);
   const [threadsLoading, setThreadsLoading] = useState(false);
 
+  const resolvedApiUrl = apiUrl || import.meta.env.VITE_API_URL;
+  const resolvedAssistantId = assistantId || import.meta.env.VITE_ASSISTANT_ID;
+
   const getThreads = useCallback(async (): Promise<Thread[]> => {
-    if (!apiUrl || !assistantId) return [];
-    const client = createClient(apiUrl, getApiKey() ?? undefined);
+    if (!resolvedApiUrl || !resolvedAssistantId) return [];
+    const client = createClient(resolvedApiUrl, getApiKey() ?? undefined);
 
     const threads = await client.threads.search({
       metadata: {
-        ...getThreadSearchMetadata(assistantId),
+        ...getThreadSearchMetadata(resolvedAssistantId),
       },
       limit: 100,
     });
 
     return threads;
-  }, [apiUrl, assistantId]);
+  }, [resolvedApiUrl, resolvedAssistantId]);
 
   const value = {
     getThreads,


### PR DESCRIPTION
## Summary

- **Conditional interrupt**: `post_tool_route` only routes to `replanner` when `retrieve_and_answer_question` remains in the plan — find-only queries now end without an interrupt
- **HITL interrupt UI**: Amber warning state when no papers are added to list, emerald ready state once papers are ingested; explanatory copy guides users through the Add-to-list → ingest → Proceed flow
- **Select all / Deselect all**: Toggle button in the paper list header for bulk checkbox selection
- **Paper list / panel fix**: Checkbox toggles no longer pollute the global `PaperSelection` context — papers only appear in "My Paper List" after clicking "Add to list"
- **Selected papers panel**: Updated copy to clarify papers are available to the research assistant
- **Landing page**: Left-aligned Corvus header with enlarged logo/title and descriptive snippet (Asta-style); updated input placeholder
- **Thread history fix**: `ThreadProvider` now applies `VITE_API_URL`/`VITE_ASSISTANT_ID` env var fallbacks so the conversation sidebar populates correctly
- **StepTracker UI**: Redesigned with per-row hover effects, consistent gray-scale palette, and divide-y layout matching the rest of the UI

## Test plan

- [ ] Find-only query (e.g. "find papers on X") — papers appear, no interrupt, conversation ends
- [ ] Find + QA query (e.g. "find papers on X and answer Y") — papers appear, amber interrupt shown, Add to list → ingest → Proceed → QA runs
- [ ] Reject path — graph ends cleanly
- [ ] Select all / Deselect all toggles work correctly
- [ ] "My Paper List" panel only updates after "Add to list", not on checkbox toggle
- [ ] Conversation history sidebar shows past threads on load
- [ ] StepTracker hover effects visible for each step status

🤖 Generated with [Claude Code](https://claude.com/claude-code)