### PR TITLE
feat: paper_finder subagent tuning + real-time status UI

### DIFF
--- a/backend/app/agent/graph.py
+++ b/backend/app/agent/graph.py
@@ -60,7 +60,10 @@ async def _optimize_for_paper_search(messages: list) -> tuple[str, str]:
         "Given the conversation history, produce two outputs: "
         "(1) a natural-language task description so a research planner knows exactly what to do, "
         "and (2) a keyword query for semantic reranking of candidate papers. "
-        "Resolve all references (e.g. 'that paper', 'it', 'their method') using context from earlier messages."
+        "Resolve all references (e.g. 'that paper', 'it', 'their method') using context from earlier messages. "
+        "For the search_task: faithfully reflect only what the user asked for. "
+        "Do NOT add sub-topics, concepts, or angles the user did not mention — "
+        "the planner will over-engineer the search plan if given extra scope."
     ))
     structured = supervisor_model.bind_tools(
         [SearchOptimizationOutput], tool_choice="SearchOptimizationOutput"

--- a/backend/app/agent/paper_finder.py
+++ b/backend/app/agent/paper_finder.py
@@ -55,13 +55,12 @@ async def planner(state: PaperFinderState):
         Examples:
         - General topic: Start with web search for context, then academic database search
         - Specific paper: Use academic database with title/author filters
-        - Foundational work: Find key papers, then use forward snowball to trace their references
-        - Recent advances: Find seminal papers, then use backward snowball for recent citations
-    - Citation chasing is powerful when you've identified good seed papers
+    - Never use citation chasing (snowball) when the user is only asking for a specific paper. e.g. Find me the Attention is all you need paper. Unless the user specifically asked for it
+    e.g. Find me the Attention is all you need paper and the papers citing it.
+    - Using citation chasing when you find a good seed paper is recommended when search for a general topic.
     - The granularity of each step should be adequate for the assistant to finish within one execution
     - Keep each step concise and to the point
-    
-    Limit the number of steps to 3 or less.
+    - Try to minimize the steps of plan as much as possible
     """
 
     paper_info_text = get_paper_info_text(state.get("papers", []))
@@ -117,14 +116,16 @@ async def replan_agent(state: PaperFinderState):
         Examples:
         - General topic: Web search for context, then academic database
         - Specific paper: Use academic database with filters
-        - If good papers found: Consider citation chasing to expand the paper set
+    - Never use citation chasing (snowball) when the user is only asking for a specific paper. e.g. Find me the Attention is all you need paper. Unless the user specifically asked for it
+    e.g. Find me the Attention is all you need paper and the papers citing it.
+    - Using citation chasing when you find a good seed paper is recommended when search for a general topic.
     - The granularity of each step should be adequate for the assistant to finish within one execution
     - Take into account the steps that your assistant has already completed and the results of those steps
     - If you think the current plan is good enough, simply remove completed steps and keep the rest
     - The completed steps should not be included in the new plan
     - Keep each step concise and to the point
-    
-    Limit the number of new steps to 2 or less.
+    - Try to minimize the steps as much as possible
+    - If the goal is already achieved, mark it as done rather than adding more steps
     """
 
     paper_info_text = get_paper_info_text(state.get("papers", []))

--- a/backend/app/agent/paper_finder.py
+++ b/backend/app/agent/paper_finder.py
@@ -63,7 +63,7 @@ async def planner(state: PaperFinderState):
     - Try to minimize the steps of plan as much as possible
     """
 
-    paper_info_text = get_paper_info_text(state.get("papers", []))
+    paper_info_text = get_paper_info_text(state.get("papers", []), include_abstract=False)
 
     user_prompt = f"""
     Task: {state['search_task']}
@@ -128,7 +128,7 @@ async def replan_agent(state: PaperFinderState):
     - If the goal is already achieved, mark it as done rather than adding more steps
     """
 
-    paper_info_text = get_paper_info_text(state.get("papers", []))
+    paper_info_text = get_paper_info_text(state.get("papers", []), include_abstract=False)
 
     user_prompt = f"""
     Task: {state['search_task']}
@@ -181,7 +181,7 @@ class SearchAgentState(AgentState):
     plan_steps: List[str]
 
 async def search_agent_node(state: SearchAgentState):
-    paper_info_text = get_paper_info_text(state.get("papers", []))
+    paper_info_text = get_paper_info_text(state.get("papers", []), include_abstract=False)
     search_query_prompt = f"""
     You are a senior research assistant who helps finding academic papers based on a user query.
     You are provided with a plan for your search from your mentor.

--- a/backend/app/agent/paper_finder.py
+++ b/backend/app/agent/paper_finder.py
@@ -54,8 +54,8 @@ async def planner(state: PaperFinderState):
     1. General web search: Understand context and find famous/seminal papers
     2. Academic database search: Find papers with keyword queries and filters (year, venue, citations, etc.)
     3. Citation chasing:
-       - Forward snowball: Find papers that seed papers cite (their foundations/references)
-       - Backward snowball: Find papers that cite seed papers (recent work building on them)
+       - Forward snowball: Find papers that CITE seed papers (recent work building on them)
+       - Backward snowball: Find papers that seed papers CITE (their foundations/references)
 
     Guidelines:
     - Every step must be a concrete search action (web search, database search, or citation chasing).
@@ -135,8 +135,8 @@ async def replan_agent(state: PaperFinderState):
     1. General web search: Understand context and find famous/seminal papers
     2. Academic database search: Find papers with keyword queries and filters
     3. Citation chasing:
-       - Forward snowball: Find papers that seed papers cite (foundations/references)
-       - Backward snowball: Find papers that cite seed papers (recent work)
+       - Forward snowball: Find papers that CITE seed papers (recent work)
+       - Backward snowball: Find papers that seed papers CITE (foundations/references)
 
     Guidelines:
     - Every step must be a concrete search action (web search, database search, or citation chasing).
@@ -234,8 +234,8 @@ async def search_agent_node(state: SearchAgentState):
        Use keyword queries, filters by year, venue, citation count, etc. to find relevant papers. Pick this tool when the goal prompts you to search academic database.
 
     3. Citation chasing tools:
-       - forward_snowball: Find papers that your seed papers CITE (their references/foundations)
-       - backward_snowball: Find papers that CITE your seed papers (recent work building on them)
+       - forward_snowball: Find papers that CITE your seed papers (recent work building on them)
+       - backward_snowball: Find papers that your seed papers CITE (their foundations/references)
        Use these when the goal explictly asks you to. 
 
     Strict limits — you are executing ONE step of a larger plan:

--- a/backend/app/agent/paper_finder_fast.py
+++ b/backend/app/agent/paper_finder_fast.py
@@ -47,7 +47,8 @@ def flexible_reducer(current: list, update: Union[list, "Replace"]) -> list:
     return current + [p for p in update if p.paperId not in seen]
 
 class SearchAgentState(AgentState):
-    optimized_query: str
+    search_task: str
+    rerank_query: str
     papers: Annotated[List[S2Paper], flexible_reducer]
     iter: int
 
@@ -101,7 +102,7 @@ async def rerank_node(state: SearchAgentState):
     if not papers:
         return {"iter": iter}
 
-    user_query = state.get("optimized_query", "")
+    user_query = state.get("rerank_query", "")
 
     if not user_query or not user_query.strip():
         logger.warning("Skipping rerank: no query provided")

--- a/backend/app/agent/paper_finder_fast.py
+++ b/backend/app/agent/paper_finder_fast.py
@@ -69,8 +69,8 @@ async def search_agent_node(state: SearchAgentState):
        Use keyword queries, filters by year, venue, citation count, etc. to find relevant papers.
 
     3. Citation chasing tools:
-       - forward_snowball: Find papers that your seed papers CITE (their references/foundations)
-       - backward_snowball: Find papers that CITE your seed papers (recent work building on them)
+       - forward_snowball: Find papers that CITE your seed papers (recent work building on them)
+       - backward_snowball: Find papers that your seed papers CITE (their foundations/references)
        Use these when you've found good papers and want to explore their citation network.
 
     Strategy tips:

--- a/backend/app/agent/paper_finder_fast.py
+++ b/backend/app/agent/paper_finder_fast.py
@@ -74,7 +74,7 @@ async def search_agent_node(state: SearchAgentState):
        Use these when you've found good papers and want to explore their citation network.
 
     Strategy tips:
-    - If the user query is about a specific paper, use the academic database search with the title/author filters to find the paper and quickly finish the task.
+    - If the user query is about a specific paper, use the academic database search with the title/author filters to find the paper and quickly finish the task. Never use citation chase (snowball) here unless specifically asked for.
     - If the user query is more general, you should follow the following strategy:
         - Start with web search if topic is unfamiliar to get context
         - Use academic database for targeted searches with filters

--- a/backend/app/agent/states.py
+++ b/backend/app/agent/states.py
@@ -28,6 +28,7 @@ class PaperFinderState(MessagesState):
     papers: List[Dict[str, Any]]
     iter: int
     goal_achieved: bool
+    ui_tracking_id: Optional[str]  # stable ID for in-place UIMessage updates
 
 class QAAgentState(MessagesState):
     evidences: Annotated[List[Document], merge_evidences]

--- a/backend/app/agent/states.py
+++ b/backend/app/agent/states.py
@@ -20,8 +20,9 @@ class SupervisorState(AgentState):
 
 
 class PaperFinderState(MessagesState):
-    optimized_query: Optional[str]
-    plan_steps: List[str]       
+    search_task: Optional[str]   # natural-language goal for the planner + search agent
+    rerank_query: Optional[str]  # keyword-optimized query used only for reranking
+    plan_steps: List[str]
     completed_steps: Annotated[List[Tuple[str, str]], operator.add]
     plan_reasoning: str
     papers: List[Dict[str, Any]]

--- a/backend/app/agent/utils.py
+++ b/backend/app/agent/utils.py
@@ -25,11 +25,24 @@ def get_user_query(messages: list) -> str:
             user_msg = m["content"]
     return user_msg 
     
-def get_paper_info_text(papers: list[S2Paper]) -> str:
+def get_paper_info_text(papers: list[S2Paper], include_abstract: bool = True) -> str:
     """Get the text of the papers."""
     if not papers:
         return "No papers found yet"
-    return "\n".join([f"Paper {paper.paperId}: {paper.title}\nAuthors: {paper.authors}\nPublication Date: {paper.publicationDate}\nAbstract: {paper.abstract}\n" for paper in papers])
+    lines = []
+    for paper in papers:
+        author_list = paper.authors or []
+        names = [a.get("name", "") for a in author_list[:3] if isinstance(a, dict) and a.get("name")]
+        authors_str = ", ".join(names) + (" et al." if len(author_list) > 3 else "")
+        parts = [
+            f"- {paper.title or 'Untitled'}",
+            f"  Authors: {authors_str or 'Unknown'}",
+            f"  Published: {paper.publicationDate or 'N/A'}",
+        ]
+        if include_abstract and paper.abstract:
+            parts.append(f"  Abstract: {paper.abstract}")
+        lines.append("\n".join(parts))
+    return "\n\n".join(lines)
 
 def get_paper_abstract(papers: List[S2Paper], selected_paper_ids: List[str]) -> Dict[str, str]:
     abstracts = {}

--- a/backend/app/tools/search.py
+++ b/backend/app/tools/search.py
@@ -246,7 +246,7 @@ async def s2_search_papers(
             )
     
     return Command(
-        update={"new_papers": new_results, "messages": [
+        update={"papers": new_results, "messages": [
             ToolMessage(
                 content=f"I found {len(new_results)} new papers for your query.",
                 tool_call_id=tool_call_id
@@ -489,7 +489,7 @@ async def forward_snowball(
         
         return Command(
             update={
-                "new_papers": result_papers,
+                "papers": result_papers,
                 "messages": [ToolMessage(
                     content=f"Found {len(result_papers)} papers cited by the {len(seed_paper_ids)} seed papers.",
                     tool_call_id=tool_call_id
@@ -654,7 +654,7 @@ async def backward_snowball(
         
         return Command(
             update={
-                "new_papers": result_papers,
+                "papers": result_papers,
                 "messages": [ToolMessage(
                     content=f"Found {len(result_papers)} papers that cite the {len(seed_paper_ids)} seed papers.",
                     tool_call_id=tool_call_id

--- a/backend/app/tools/search.py
+++ b/backend/app/tools/search.py
@@ -347,18 +347,18 @@ def get_paper_details(
     return paper_info_text
 
 
-class ForwardSnowballRequest(BaseModel):
-    """Request schema for forward snowball search."""
+class BackwardSnowballRequest(BaseModel):
+    """Request schema for backward snowball search."""
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    
+
     runtime: ToolRuntime
     reasoning: str = Field(
-        ..., 
-        description="Explain why you want to find papers that these seed papers cite/reference"
+        ...,
+        description="Explain why you want to trace back the foundational papers that these seed papers cite"
     )
     seed_paper_ids: List[str] = Field(
         ...,
-        description="List of Semantic Scholar paper IDs to use as seed papers. These are the papers whose references you want to explore."
+        description="List of Semantic Scholar paper IDs to use as seed papers. These are the papers whose references (bibliography) you want to explore."
     )
     top_k: int = Field(
         10,
@@ -366,36 +366,36 @@ class ForwardSnowballRequest(BaseModel):
     )
 
 
-@tool(args_schema=ForwardSnowballRequest)
-async def forward_snowball(
+@tool(args_schema=BackwardSnowballRequest)
+async def backward_snowball(
     runtime: ToolRuntime,
     reasoning: str,
     seed_paper_ids: List[str],
     top_k: int = 10
 ):
     """
-    Forward Snowball: Find papers that the specified seed papers CITE (their references).
-    
+    Backward Snowball: Trace foundational papers by following what seed papers CITE (their references/bibliography).
+
     **What this does:**
     - Takes a list of paper IDs as seed papers
     - Fetches all papers that these seed papers reference/cite
     - Scores candidates based on citation count and how many seeds cite them
     - Returns the top-k most relevant referenced papers
-    
+
     **When to use:**
     - You want to explore the foundational papers that influenced specific papers
     - You're tracing back to the original/parent works
     - You want to understand what prior work specific papers build upon
-    
+
     **Example:**
-    For papers about "GPT-3" and "BERT", this will find papers like 
+    For papers about "GPT-3" and "BERT", this will find papers like
     "Attention is All You Need" (Transformer paper) that they cite.
-    
+
     Args:
         reasoning: Why you want to find referenced papers
         seed_paper_ids: List of Semantic Scholar paper IDs (e.g., ["paperId1", "paperId2"])
         top_k: Number of top papers to return (default: 10, max: 50)
-        
+
     Returns:
         Top-k most relevant papers cited by the seed papers
     """
@@ -500,24 +500,24 @@ async def forward_snowball(
     except Exception as e:
         return Command(
             update={"messages": [ToolMessage(
-                content=f"Error during forward snowball: {str(e)}",
+                content=f"Error during backward snowball: {str(e)}",
                 tool_call_id=tool_call_id
             )]}
         )
 
 
-class BackwardSnowballRequest(BaseModel):
-    """Request schema for backward snowball search."""
+class ForwardSnowballRequest(BaseModel):
+    """Request schema for forward snowball search."""
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    
+
     runtime: ToolRuntime
     reasoning: str = Field(
-        ..., 
-        description="Explain why you want to find papers that cite these seed papers"
+        ...,
+        description="Explain why you want to find newer papers that cite these seed papers"
     )
     seed_paper_ids: List[str] = Field(
         ...,
-        description="List of Semantic Scholar paper IDs to use as seed papers. These are the papers whose citations you want to explore."
+        description="List of Semantic Scholar paper IDs to use as seed papers. These are the papers whose citations (papers that cite them) you want to explore."
     )
     top_k: int = Field(
         10,
@@ -525,36 +525,36 @@ class BackwardSnowballRequest(BaseModel):
     )
 
 
-@tool(args_schema=BackwardSnowballRequest)
-async def backward_snowball(
+@tool(args_schema=ForwardSnowballRequest)
+async def forward_snowball(
     runtime: ToolRuntime,
     reasoning: str,
     seed_paper_ids: List[str],
     top_k: int = 10
 ):
     """
-    Backward Snowball: Find papers that CITE the specified seed papers.
-    
+    Forward Snowball: Find newer work by following who CITES the seed papers.
+
     **What this does:**
     - Takes a list of paper IDs as seed papers
     - Fetches all papers that cite these seed papers
     - Scores candidates based on citation count, recency, and how many seeds they cite
     - Returns the top-k most relevant citing papers
-    
+
     **When to use:**
     - You want to find recent work building on specific foundational papers
     - You're looking for "child" papers that extend or apply seed papers
     - You want to discover how specific papers have been used or cited
-    
+
     **Example:**
-    For the "Attention is All You Need" paper, this will find papers like 
+    For the "Attention is All You Need" paper, this will find papers like
     "BERT", "GPT-3", and other transformer-based models that cite it.
-    
+
     Args:
         reasoning: Why you want to find citing papers
         seed_paper_ids: List of Semantic Scholar paper IDs (e.g., ["paperId1", "paperId2"])
         top_k: Number of top papers to return (default: 10, max: 50)
-        
+
     Returns:
         Top-k most relevant papers that cite the seed papers
     """
@@ -661,11 +661,11 @@ async def backward_snowball(
                 )]
             }
         )
-        
+
     except Exception as e:
         return Command(
             update={"messages": [ToolMessage(
-                content=f"Error during backward snowball: {str(e)}",
+                content=f"Error during forward snowball: {str(e)}",
                 tool_call_id=tool_call_id
             )]}
         )

--- a/web/src/components/agent/ui.tsx
+++ b/web/src/components/agent/ui.tsx
@@ -25,7 +25,7 @@ export const StepTracker = ({ steps }: StepTrackerProps) => {
         <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
         </svg>
-        <h3 className="text-base font-semibold text-gray-900">Agent Actions</h3>
+        <h3 className="text-base font-semibold text-gray-900">Supervisor Agent</h3>
       </div>
 
       {/* Steps */}
@@ -95,6 +95,62 @@ export const StepTracker = ({ steps }: StepTrackerProps) => {
     </div>
   );
 };
+
+// ============================================
+// PaperFinderStatus Component
+// ============================================
+
+interface PaperFinderStatusProps {
+  label: string;
+  status: 'running' | 'completed';
+  description?: string;
+}
+
+export const PaperFinderStatus = ({ label, status, description }: PaperFinderStatusProps) => (
+  <div className="w-xl max-w-3xl rounded-lg border border-gray-200 bg-white shadow-sm overflow-hidden">
+    {/* Header */}
+    <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-200">
+      <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+      </svg>
+      <h3 className="text-base font-semibold text-gray-900">Research Agent</h3>
+      <span className="ml-auto text-xs font-medium text-gray-400 bg-gray-100 px-2 py-0.5 rounded-full">
+        subagent
+      </span>
+    </div>
+
+    {/* Single status row */}
+    <div className="flex items-start gap-3 px-4 py-3">
+      <div className="flex-shrink-0 mt-0.5 w-5 h-5 flex items-center justify-center">
+        {status === 'running' ? (
+          <svg className="w-5 h-5 text-gray-900 animate-spin" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+            <path className="opacity-75" fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+          </svg>
+        ) : (
+          <svg className="w-5 h-5 text-gray-900" fill="currentColor" viewBox="0 0 20 20">
+            <path fillRule="evenodd"
+              d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+              clipRule="evenodd" />
+          </svg>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className={`text-sm font-medium leading-snug ${status === 'running' ? 'text-gray-900' : 'text-gray-600'}`}>
+          {label}
+        </p>
+        {description && (
+          <p className="text-xs text-gray-400 mt-0.5 leading-snug">{description}</p>
+        )}
+      </div>
+      {status === 'running' && (
+        <span className="flex-shrink-0 self-center text-xs text-gray-500">Running…</span>
+      )}
+    </div>
+  </div>
+);
 
 // ============================================
 // Paper Components

--- a/web/src/components/thread/messages/ai.tsx
+++ b/web/src/components/thread/messages/ai.tsx
@@ -14,7 +14,7 @@ import { ThreadView } from "../agent-inbox";
 import { useQueryState, parseAsBoolean } from "nuqs";
 import { GenericInterruptView } from "./generic-interrupt";
 import { SelectPapersInterruptView } from "./select-papers-interrupt";
-import { PaperComponent, PaperListComponent, StepTracker } from "@/components/agent/ui";
+import { PaperComponent, PaperListComponent, StepTracker, PaperFinderStatus } from "@/components/agent/ui";
 
 function CustomComponent({
   message,
@@ -39,7 +39,8 @@ function CustomComponent({
           components={{
             paper: PaperComponent as any,
             papers: PaperListComponent as any,
-            steps: StepTracker as any
+            steps: StepTracker as any,
+            finder_status: PaperFinderStatus as any,
           }}
           meta={{ ui: customComponent }}
         />


### PR DESCRIPTION
## Summary

- **Real-time PaperFinderStatus UI**: a "Research Agent" card with spinner/checkmark updates live during the `find_papers` tool call, anchored to the already-committed tool-caller AIMessage so it renders during streaming rather than only after the tool completes
- **Fix event forwarding**: the custom event forwarding in `find_papers` was double-wrapping the UI envelope (passing `type="ui"` as the name); now correctly unwraps `name` + `props` from the inner event
- **Snowball naming corrected**: `forward_snowball` / `backward_snowball` were inverted vs. academic convention — fixed across tool implementations, schemas, docstrings, and all prompt descriptions
- **Prompt improvements**: `replan_agent` now has concrete goal-achieved thresholds (≥1 paper for specific lookups, ≥5 for broad topics); `search_agent_node` now shows upcoming plan steps so the agent avoids pre-empting later work
- **search_task / rerank_query split**: planner receives a natural-language task description; reranker gets a separate keyword-style query
- **Miscellaneous**: restrict snowball to explicit user requests, prevent search_task from over-specifying user intent, clean up dead code, improve `get_paper_info_text` formatting

## Test plan

- [ ] Send a broad paper search query and confirm the "Research Agent" subagent card appears in real-time with spinner → cycling labels → checkmark
- [ ] Confirm no duplicate cards (same stable ID reused across updates)
- [ ] Confirm `forward_snowball` now finds papers that cite the seeds; `backward_snowball` finds foundational references
- [ ] Confirm `replan_agent` stops early for specific paper lookups (1 result = done)
- [ ] Confirm search agent does not pre-empt steps listed as upcoming in its prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)