### PR TITLE
fix(qa): improve QA reliability and fix ingestion/config issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.env
+**/.env*
+!**/.env_example
 
 # Large data files
 backend/eval/data/scidocs/corpus.jsonl

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: dev dev-cloud worker worker-cloud frontend infra
+
+# ── Local development (localhost Qdrant, Redis, Grobid) ─────────────────────
+dev:
+	cd backend && uv run langgraph dev
+
+worker:
+	cd backend && uv run python -m celery -A app.celery_app worker --loglevel=info --pool=solo
+
+# ── Cloud configuration ───────────────────────────────────────────────────────
+dev-cloud:
+	cd backend && ENV_FILE=.env.cloud uv run langgraph dev
+
+worker-cloud:
+	cd backend && ENV_FILE=.env.cloud uv run python -m celery -A app.celery_app worker --loglevel=info --pool=solo
+
+# ── Frontend ──────────────────────────────────────────────────────────────────
+frontend:
+	cd web && pnpm dev
+
+# ── Infrastructure (local Docker services) ───────────────────────────────────
+infra:
+	docker compose up -d

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # ── Local development (localhost Qdrant, Redis, Grobid) ─────────────────────
 dev:
-	cd backend && uv run langgraph dev
+	cd backend && uv run langgraph dev --allow-blocking
 
 worker:
 	cd backend && uv run python -m celery -A app.celery_app worker --loglevel=info --pool=solo

--- a/README.md
+++ b/README.md
@@ -146,42 +146,49 @@ cd Corvus
 ### 2. Configure environment
 
 ```bash
-cp backend/.env_example backend/.env
+cp backend/.env_example backend/.env.local
 ```
 
-Edit `backend/.env` and set at minimum:
+Edit `backend/.env.local` and fill in at minimum:
 
-- `OPENAI_API_KEY`
-- `COHERE_API_KEY`
-- `S2_API_KEY`
+- `OPENAI_API_KEY` — for embeddings
+- `GEMINI_API_KEY` — for all agent LLM calls
+- `COHERE_API_KEY` — for reranking
+- `S2_API_KEY` — for Semantic Scholar search
+
+Local infrastructure variables (Qdrant, Redis, Grobid) are pre-filled with `localhost` defaults.
 
 ### 3. Start infrastructure
 
 ```bash
-docker compose up -d
+make infra
 ```
 
-Starts Postgres (5432), Redis (6379), Qdrant (6333), and Grobid (8070).
+Starts Redis (6379), Qdrant (6333), and Grobid (8070) via Docker Compose.
 
-### 4. Start the Celery worker
+### 4. Start the Celery worker, backend, and frontend
 
-```bash
-cd backend && uv run python -m celery -A app.celery_app worker --loglevel=info --pool=solo
-```
-
-### 5. Start the backend
+Open three terminals and run:
 
 ```bash
-cd backend && uv run langgraph dev
-```
-
-### 6. Start the frontend
-
-```bash
-cd web && pnpm install && pnpm dev
+make worker    # Celery worker
+make dev       # LangGraph backend  (http://localhost:2024)
+make frontend  # React frontend     (http://localhost:5173)
 ```
 
 Open `http://localhost:5173`.
+
+### Switching to cloud services
+
+To run against your deployed Qdrant, Redis, and Grobid instead:
+
+```bash
+cp backend/.env_example backend/.env.cloud
+# fill in cloud service URLs and API keys
+
+make dev-cloud
+make worker-cloud
+```
 
 ## Documentation
 

--- a/backend/.env_example
+++ b/backend/.env_example
@@ -13,9 +13,10 @@ QA_EVALUATOR_MODEL_NAME=google_genai:gemini-3-pro-preview
 QA_BASELINE_MODEL_NAME=google_genai:gemini-3-flash-preview
 
 # ── LangSmith tracing (optional) ───────────────────────────────────────────
-LANGSMITH_TRACING_V2=false
+LANGCHAIN_TRACING_V2=true
 LANGCHAIN_API_KEY=your_langchain_api_key
-LANGCHAIN_PROJECT=ai-researcher-proto
+LANGCHAIN_PROJECT=corvus
+LANGCHAIN_ENDPOINT=https://api.smith.langchain.com
 
 # ── External APIs ──────────────────────────────────────────────────────────
 COHERE_API_KEY=your_cohere_api_key          # required for reranking

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -127,7 +127,8 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+.env*
+!.env_example
 .venv
 env/
 venv/

--- a/backend/app/agent/states.py
+++ b/backend/app/agent/states.py
@@ -35,6 +35,7 @@ class QAAgentState(MessagesState):
     limitation: str
     qa_iteration: int
     selected_paper_ids: List[str]
+    unindexed_paper_ids: List[str]  # paper IDs with no vectors in Qdrant (failed/skipped ingestion)
     sufficient_evidence: bool
     user_query: str
     papers: List[S2Paper]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,6 +1,12 @@
+import os
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pathlib import Path
 from pydantic import BaseModel
+
+_backend_dir = Path(__file__).parent.parent.parent
+# ENV_FILE can be set to switch between configurations, e.g.:
+#   ENV_FILE=.env.cloud uv run langgraph dev
+_env_file = os.getenv("ENV_FILE", str(_backend_dir / ".env.local"))
 
 
 class QdrantConfig(BaseModel):
@@ -17,7 +23,7 @@ class CeleryConfig(BaseModel):
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
-        env_file=Path(__file__).parent.parent.parent / ".env",
+        env_file=_env_file,
         env_file_encoding="utf-8",
         extra="ignore",
         validate_assignment=True,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -33,13 +33,19 @@ class Settings(BaseSettings):
     # Logging configuration
     LOG_LEVEL: str = "INFO"  # DEBUG, INFO, WARNING, ERROR, CRITICAL
 
-    # API keys — declared here so pydantic-settings reads them from the env
-    # file; model_post_init then writes them back to os.environ so that
-    # LangChain, OpenAI SDK, and other libraries that read os.environ directly
-    # pick them up regardless of how the process was started.
+    # API keys and tracing vars — declared here so pydantic-settings reads them
+    # from the env file; model_post_init then writes them back to os.environ so
+    # that LangChain, OpenAI SDK, and other libraries that read os.environ
+    # directly pick them up regardless of how the process was started.
     OPENAI_API_KEY: str = ""
     GEMINI_API_KEY: str = ""
     TAVILY_API_KEY: str = ""
+
+    # LangSmith tracing (optional)
+    LANGCHAIN_TRACING_V2: str = ""
+    LANGCHAIN_API_KEY: str = ""
+    LANGCHAIN_PROJECT: str = ""
+    LANGCHAIN_ENDPOINT: str = ""
 
     EMBEDDING_MODEL_NAME: str
 
@@ -75,8 +81,16 @@ class Settings(BaseSettings):
     DISABLE_AUTH: bool = False
 
     def model_post_init(self, __context: Any) -> None:
-        """Push API keys into os.environ so LangChain/OpenAI SDKs can find them."""
-        for key in ("OPENAI_API_KEY", "GEMINI_API_KEY", "TAVILY_API_KEY"):
+        """Push API keys and tracing vars into os.environ so LangChain/OpenAI SDKs can find them."""
+        for key in (
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "TAVILY_API_KEY",
+            "LANGCHAIN_TRACING_V2",
+            "LANGCHAIN_API_KEY",
+            "LANGCHAIN_PROJECT",
+            "LANGCHAIN_ENDPOINT",
+        ):
             value = getattr(self, key, "")
             if value:
                 os.environ.setdefault(key, value)

--- a/web/src/components/agent/ui.tsx
+++ b/web/src/components/agent/ui.tsx
@@ -496,7 +496,7 @@ export const PaperListComponent = (props: PaperListComponentProps) => {
               <p className="text-xs text-gray-400 py-1">Preparing tasks…</p>
             )}
             {taskStatuses.map(ts => {
-              const isSuccess = ts.state === 'SUCCESS' && ts.result?.method !== 'skipped';
+              const isSuccess = ts.state === 'SUCCESS' && ts.result?.method !== 'skipped' && ts.result?.success !== false;
               const isSkipped = ts.state === 'SUCCESS' && ts.result?.method === 'skipped';
               const isFailed = ts.state === 'FAILURE' || ts.result?.success === false;
               const isActive = ts.state === 'STARTED';
@@ -523,11 +523,19 @@ export const PaperListComponent = (props: PaperListComponentProps) => {
                 : 'text-gray-400';
 
               const paper = props.papers.find(p => p.paperId === ts.paperId);
+              const errorMsg = isFailed ? (ts.result?.error ?? 'Unknown error') : null;
               return (
-                <div key={ts.taskId} className="flex items-center gap-2.5 text-xs py-0.5">
-                  {dot}
-                  <span className={`${labelColor} w-32 shrink-0`}>{label}</span>
-                  <span className="text-gray-500 truncate">{paper?.title ?? ts.paperId}</span>
+                <div key={ts.taskId} className="flex items-start gap-2.5 text-xs py-0.5">
+                  <span className="mt-0.5 shrink-0">{dot}</span>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className={`${labelColor} shrink-0`}>{label}</span>
+                      <span className="text-gray-500 truncate">{paper?.title ?? ts.paperId}</span>
+                    </div>
+                    {errorMsg && (
+                      <p className="text-red-400 mt-0.5 leading-tight">{errorMsg}</p>
+                    )}
+                  </div>
                 </div>
               );
             })}


### PR DESCRIPTION
## Summary

- **QA unindexed paper detection**: On first retrieval iteration, checks Qdrant for each selected paper upfront and records `unindexed_paper_ids` in state. The evaluator no longer loops for papers with no full text; the answer node adds a single end-of-response caveat instead of leading with limitations.
- **QA prompts**: Rewritten to answer-first framing — lead with what the evidence says, single optional caveat at the end for unindexed papers.
- **Ingestion clean failure path**: Removed abstract-only fallback that was polluting Qdrant and blocking re-ingestion. Failed ingestions now return specific error strings (arXiv not found, PDF processing failed).
- **Ingestion UI fix**: Celery `state=SUCCESS` with `result.success=false` was incorrectly shown as "ingested". Fixed `isSuccess` check; failed rows now show the backend error message in red.
- **Config**: `model_post_init` now pushes `OPENAI_API_KEY`, `GEMINI_API_KEY`, `TAVILY_API_KEY`, and all LangSmith tracing vars (`LANGCHAIN_TRACING_V2`, `LANGCHAIN_API_KEY`, `LANGCHAIN_PROJECT`, `LANGCHAIN_ENDPOINT`) into `os.environ` so LangChain/OpenAI SDKs pick them up from the env file automatically.
- **Multi-env file support**: `ENV_FILE` env var selects which `.env.*` file to load (defaults to `.env.local`).
- **Blockbuster fix**: `QdrantService` init wrapped in closures so blocking socket calls run inside `asyncio.to_thread`. Added `--allow-blocking` to `langgraph dev` in Makefile as the authoritative fix (since `asyncio.to_thread` propagates `contextvars.Context`).

## Test plan

- [ ] Start infra: `make infra`
- [ ] Start worker: `make worker`
- [ ] Start backend: `make dev`
- [ ] Start frontend: `make frontend` (or `cd web && pnpm dev`)
- [ ] Search for papers and verify QA works on indexed papers
- [ ] Ask a question involving a paper that failed ingestion — verify answer leads with content, ends with single caveat, no infinite evaluation loop
- [ ] Verify failed ingestion rows show red error message (not "Ingested")
- [ ] Enable LangSmith tracing in `.env.local` and verify traces appear at smith.langchain.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)